### PR TITLE
Changing types names and adding new types to match pino

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,32 @@
 import createHttpWriteStream from "./httpStream"
 import createConsoleWriteStream from "./consoleStream"
-import {pinoBrowserLogEventI, formatPinoBrowserLogEvent, addLogflareTransformDirectives} from "./utils"
-import {LogflareHttpClient, LogflareUserOptionsI} from "logflare-transport-core"
+import {
+  LogEvent,
+  formatPinoBrowserLogEvent,
+  addLogflareTransformDirectives,
+} from "./utils"
+import {
+  LogflareHttpClient,
+  LogflareUserOptionsI,
+} from "logflare-transport-core"
 
-const isBrowser = typeof window !== 'undefined'
-  && typeof window.document !== 'undefined'
+const isBrowser =
+  typeof window !== "undefined" && typeof window.document !== "undefined"
 
-const isNode = typeof process !== 'undefined'
-  && process.versions != null
-  && process.versions.node != null
+const isNode =
+  typeof process !== "undefined" &&
+  process.versions != null &&
+  process.versions.node != null
 
 const createPinoBrowserSend = (options: LogflareUserOptionsI) => {
-  const client = new LogflareHttpClient({...options, fromBrowser: true})
+  const client = new LogflareHttpClient({ ...options, fromBrowser: true })
 
-  return (level: string, logEvent: pinoBrowserLogEventI) => {
+  return (level: string, logEvent: LogEvent) => {
     const logflareLogEvent = formatPinoBrowserLogEvent(logEvent)
-    const maybeWithTransforms = addLogflareTransformDirectives(logflareLogEvent, options)
+    const maybeWithTransforms = addLogflareTransformDirectives(
+      logflareLogEvent,
+      options
+    )
     client.postLogEvents([maybeWithTransforms])
   }
 }
@@ -29,4 +40,10 @@ const logflarePinoVercel = (options: LogflareUserOptionsI) => {
 
 const createWriteStream = createHttpWriteStream
 
-export {createWriteStream, logflarePinoVercel, createPinoBrowserSend, createConsoleWriteStream, createHttpWriteStream}
+export {
+  createWriteStream,
+  logflarePinoVercel,
+  createPinoBrowserSend,
+  createConsoleWriteStream,
+  createHttpWriteStream,
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,14 +18,26 @@ function levelToStatus(level: number) {
   return "info"
 }
 
-interface pinoBrowserLogEventI {
-  ts: number
-  messages: string[]
-  bindings: object[]
-  level: { value: number; label: string }
+type Level = "fatal" | "error" | "warn" | "info" | "debug" | "trace"
+type SerializerFn = (value: any) => any
+
+interface Bindings {
+  level?: Level | string
+  serializers?: { [key: string]: SerializerFn }
+  [key: string]: any
 }
 
-const formatPinoBrowserLogEvent = (logEvent: pinoBrowserLogEventI) => {
+interface LogEvent {
+  ts: number
+  messages: any[]
+  bindings: Bindings[]
+  level: {
+    label: string
+    value: number
+  }
+}
+
+const formatPinoBrowserLogEvent = (logEvent: LogEvent) => {
   const {
     ts,
     messages,
@@ -107,6 +119,6 @@ function toLogEntry(item: Record<string, any>): Record<string, any> {
 export {
   toLogEntry,
   formatPinoBrowserLogEvent,
-  pinoBrowserLogEventI,
+  LogEvent,
   addLogflareTransformDirectives,
 }


### PR DESCRIPTION
When using typescript the default types don't match, between pino and pino-logflare, this fix makes so that the types in pino-logflare match the pino types