### PR TITLE
fix: stream npm module has been depreacted and breaks with latest Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "pino": "^6.3.2",
     "pumpify": "^2.0.1",
     "split2": "^3.1.1",
-    "stream": "0.0.2",
+    "stream-browserify": "^3.0.0",
     "through2": "^3.0.1"
   },
   "prettier": {

--- a/src/consoleStream.ts
+++ b/src/consoleStream.ts
@@ -1,8 +1,8 @@
-import {toLogEntry} from "./utils"
+import { toLogEntry } from "./utils"
 import _ from "lodash"
-import stream from "stream"
-import {LogflareUserOptionsI} from "logflare-transport-core"
-import {addLogflareTransformDirectives} from "./utils"
+import stream from "stream-browserify"
+import { LogflareUserOptionsI } from "logflare-transport-core"
+import { addLogflareTransformDirectives } from "./utils"
 
 const createConsoleWriteStream = (options: LogflareUserOptionsI) => {
   const writeStream = new stream.Writable({
@@ -10,15 +10,17 @@ const createConsoleWriteStream = (options: LogflareUserOptionsI) => {
     highWaterMark: 1,
   })
 
-  writeStream._write = (chunk, encoding, callback) => {
+  writeStream._write = (chunk: any, encoding: any, callback: any) => {
     const batch = Array.isArray(chunk) ? chunk : [chunk]
     _(batch)
       .map(JSON.parse)
       .map(toLogEntry)
-      .map((logEntry: Record<string, any>) => addLogflareTransformDirectives(logEntry, options))
+      .map((logEntry: Record<string, any>) =>
+        addLogflareTransformDirectives(logEntry, options)
+      )
       .map(JSON.stringify)
       .forEach((x) => {
-        process.stdout.write(x + '\n')
+        process.stdout.write(x + "\n")
       })
 
     callback()

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,5 @@
 import { logflarePinoVercel, createWriteStream } from "./index"
-import { Writable } from "stream"
+import { Writable } from "stream-browserify"
 import pino from "pino"
 import Pumpify from "pumpify"
 import { mockProcessStdout } from "jest-mock-process"

--- a/src/types/stream-browserify/index.d.ts
+++ b/src/types/stream-browserify/index.d.ts
@@ -1,0 +1,1 @@
+declare module "stream-browserify"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2136,11 +2136,6 @@ electron-to-chromium@^1.3.649:
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.678.tgz#c7c6960463167126b7ed076fade14cac6223bfff"
   integrity sha512-E5ha1pE9+aWWrT2fUD5wdPBWUnYtKnEnloewbtVyrkAs79HvodOiNO4rMR94+hKbxgMFQG4fnPQACOc1cfMfBg==
 
-emitter-component@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz#065e2dbed6959bf470679edabeaf7981d1003ab6"
-  integrity sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY=
-
 emittery@^0.7.1:
   version "0.7.2"
   resolved "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz#25595908e13af0f5674ab419396e2fb394cdfa82"
@@ -2912,7 +2907,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@^2.0.4:
+inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4457,7 +4452,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@2 || 3", readable-stream@^3.0.0, readable-stream@^3.1.1:
+"readable-stream@2 || 3", readable-stream@^3.0.0, readable-stream@^3.1.1, readable-stream@^3.5.0:
   version "3.6.0"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -4961,17 +4956,18 @@ stealthy-require@^1.1.1:
   resolved "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
+stream-browserify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
+  integrity sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==
+  dependencies:
+    inherits "~2.0.4"
+    readable-stream "^3.5.0"
+
 stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
-
-stream@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz#7f5363f057f6592c5595f00bc80a27f5cec1f0ef"
-  integrity sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=
-  dependencies:
-    emitter-component "^1.1.1"
 
 string-length@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
# Background

In Node 14 there is a function called `Transform`, and pino-logflare is using a npm library called `stream` which only supports NodeJs 0.8. Some library requiring `Transform` will reference the installed one with an undefined `Transform`, which would break the whole app.

# Solution

`stream-browserify` is a better alternative than `stream`, which uses Node.js's `readable-stream` as the core to avoid breaking the app with the lose of reference.