### PR TITLE
fix #13

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import createHttpWriteStream from "./httpStream"
 import createConsoleWriteStream from "./consoleStream"
 import {
+  Level,
   LogEvent,
   formatPinoBrowserLogEvent,
   addLogflareTransformDirectives,
@@ -21,7 +22,7 @@ const isNode =
 const createPinoBrowserSend = (options: LogflareUserOptionsI) => {
   const client = new LogflareHttpClient({ ...options, fromBrowser: true })
 
-  return (level: string | number, logEvent: LogEvent) => {
+  return (level: Level, logEvent: LogEvent) => {
     const logflareLogEvent = formatPinoBrowserLogEvent(logEvent)
     const maybeWithTransforms = addLogflareTransformDirectives(
       logflareLogEvent,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -119,6 +119,7 @@ function toLogEntry(item: Record<string, any>): Record<string, any> {
 export {
   toLogEntry,
   formatPinoBrowserLogEvent,
+  Level,
   LogEvent,
   addLogflareTransformDirectives,
 }


### PR DESCRIPTION
I was still seeing #13 while using `0.3.10`, pino `6.11.3` and @types/pino `6.3.9`

I believe this updates the signature to match Pino's 