### PR TITLE
chore: Remove axios dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "typescript": "^4.2.0"
   },
   "dependencies": {
-    "axios": "^0.21.1",
     "batch2": "^1.0.6",
     "commander": "^5.0.0",
     "fast-json-parse": "^1.0.3",


### PR DESCRIPTION
This PR removes `axios` as a directly dependency of this project. It was not actually used in this project, only in logflare-transport-core-js, so this PR is very small.

This PR is related to https://github.com/Logflare/logflare-transport-core-js/pull/10

