### PR TITLE
chore: Remove stream-browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "pino": "^6.3.2",
     "pumpify": "^2.0.1",
     "split2": "^3.1.1",
-    "stream-browserify": "^3.0.0",
     "through2": "^3.0.1"
   },
   "prettier": {

--- a/src/consoleStream.test.js
+++ b/src/consoleStream.test.js
@@ -1,20 +1,19 @@
-import {mockProcessStdout} from 'jest-mock-process'
+import { mockProcessStdout } from "jest-mock-process"
 
-describe('Console stream', () => {
+describe("Console stream", () => {
   let consoleStream
   let mockStdout
 
   beforeAll(() => {
     mockStdout = mockProcessStdout()
-    consoleStream = require('./consoleStream').default
+    consoleStream = require("./consoleStream").default
   })
 
-  it('streams correctly', () => {
+  it("streams correctly", () => {
     const stream = consoleStream()
     stream.write(
-      JSON.stringify({id: 1, name: `item first`, time: 1594310416073})
+      JSON.stringify({ id: 1, name: `item first`, time: 1594310416073 })
     )
-    stream.end()
 
     expect(mockStdout).toHaveBeenCalledWith(
       '{"metadata":{"id":1,"name":"item first","context":{},"level":"info"},"message":"info","timestamp":1594310416073}\n'

--- a/src/consoleStream.ts
+++ b/src/consoleStream.ts
@@ -1,30 +1,23 @@
 import { toLogEntry } from "./utils"
-import stream from "stream-browserify"
 import { LogflareUserOptionsI } from "logflare-transport-core"
 import { addLogflareTransformDirectives } from "./utils"
 
 const createConsoleWriteStream = (options: LogflareUserOptionsI) => {
-  const writeStream = new stream.Writable({
-    objectMode: true,
-    highWaterMark: 1,
-  })
-
-  writeStream._write = (chunk: any, encoding: any, callback: any) => {
-    const batch = Array.isArray(chunk) ? chunk : [chunk]
-    batch
-      .map((chunkItem) => JSON.parse(chunkItem))
-      .map(toLogEntry)
-      .map((logEntry: Record<string, any>) =>
-        addLogflareTransformDirectives(logEntry, options)
-      )
-      .map((chunkItem) => JSON.stringify(chunkItem))
-      .forEach((x) => {
-        process.stdout.write(x + "\n")
-      })
-
-    callback()
+  return {
+    write: (chunk: any) => {
+      const batch = Array.isArray(chunk) ? chunk : [chunk]
+      batch
+        .map((chunkItem) => JSON.parse(chunkItem))
+        .map(toLogEntry)
+        .map((logEntry: Record<string, any>) =>
+          addLogflareTransformDirectives(logEntry, options)
+        )
+        .map((chunkItem) => JSON.stringify(chunkItem))
+        .forEach((x) => {
+          process.stdout.write(x + "\n")
+        })
+    },
   }
-  return writeStream
 }
 
 export default createConsoleWriteStream

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,4 @@
 import { logflarePinoVercel, createWriteStream } from "./index"
-import { Writable } from "stream-browserify"
 import pino from "pino"
 import Pumpify from "pumpify"
 import { mockProcessStdout } from "jest-mock-process"
@@ -12,7 +11,7 @@ describe("main", () => {
       sourceToken: "testSourceToken",
     })
 
-    expect(stream).toBeInstanceOf(Writable)
+    expect(stream.write).toBeInstanceOf(Function)
     expect(send).toBeInstanceOf(Function)
     done()
   })

--- a/src/types/stream-browserify/index.d.ts
+++ b/src/types/stream-browserify/index.d.ts
@@ -1,1 +1,0 @@
-declare module "stream-browserify"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,7 +2907,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.4:
+inherits@2, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4452,7 +4452,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@2 || 3", readable-stream@^3.0.0, readable-stream@^3.1.1, readable-stream@^3.5.0:
+"readable-stream@2 || 3", readable-stream@^3.0.0, readable-stream@^3.1.1:
   version "3.6.0"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -4955,14 +4955,6 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
-
-stream-browserify@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
-  integrity sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==
-  dependencies:
-    inherits "~2.0.4"
-    readable-stream "^3.5.0"
 
 stream-shift@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Related to #41 

This PR changes the return value of `createConsoleWriteStream` from a Writable stream to an object that has a `write` method. By doing so, it removes the need to include `stream-browserify` (and `readable-stream`) in bundles.

This approach is documented in the first sentence under this section in Pino's docs.
https://getpino.io/#/docs/api?id=destination-sonicboom-writablestream-string-object