### PR TITLE
chore: transport core version bump

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2,40 +2,42 @@
 
 The library exposes functions to write directly to Logflare from your own application either from the server and/or the client.
 
-
 Example:
 
 ```js
-import pino from 'pino'
-import { createPinoBrowserSend, createWriteStream } from 'pino-logflare'
+import pino from "pino"
+import { createPinoBrowserSend, createWriteStream } from "pino-logflare"
 
 // create pino-logflare stream
 const stream = createWriteStream({
-    apiKey: "YOUR_API_KEY",
-    sourceToken: "b1b334ff-686c-472d-8fd7-XXXXXXXXXXXX"
-});
+  apiKey: "YOUR_API_KEY",
+  sourceToken: "b1b334ff-686c-472d-8fd7-XXXXXXXXXXXX",
+})
 
 // create pino-logflare browser stream
 const send = createPinoBrowserSend({
-    apiKey: "YOUR_API_KEY",
-    sourceToken: "b1b334ff-686c-472d-8fd7-XXXXXXXXXXXX"
-});
+  apiKey: "YOUR_API_KEY",
+  sourceToken: "b1b334ff-686c-472d-8fd7-XXXXXXXXXXXX",
+})
 
 // create pino loggger
-const logger = pino({
+const logger = pino(
+  {
     browser: {
-        transmit: {
-            send: send,
-        }
-    }
-}, stream);
+      transmit: {
+        send: send,
+      },
+    },
+  },
+  stream
+)
 
 // log some events
-logger.info("Informational message");
-logger.error(new Error("things got bad"), "error message");
+logger.info("Informational message")
+logger.error(new Error("things got bad"), "error message")
 
-const child = logger.child({ property: "value" });
-child.info("hello child!");
+const child = logger.child({ property: "value" })
+child.info("hello child!")
 ```
 
 # JavaScript numbers to floats typecasting
@@ -48,10 +50,9 @@ const stream = logflare.createWriteStream({
   apiBaseUrl: "http://localhost:4000",
   sourceToken: "6856e043-c872-47ff-96b3-dc4af93eeb12",
   transforms: {
-    numbersToFloats: true
-  }
-});
-
+    numbersToFloats: true,
+  },
+})
 ```
 
 ## Functions
@@ -65,7 +66,20 @@ Example:
 ```js
 const writeStream = createWriteStream({
   apiKey: "API_KEY",
+  sourceToken: "49e4f31e-f7e9-4f42-8c1e-xxxxxxxxxx",
+})
+```
+
+To handle ingestion errors, add in the following option:
+
+```js
+const writeStream = createWriteStream({
+  apiKey: "API_KEY",
   sourceToken: "49e4f31e-f7e9-4f42-8c1e-xxxxxxxxxx"
+  // optional callback, callback be invoked on each error raised
+  onError: (payload, err)=> {
+    // do something with the ingestion payload that would have been sent to Logflare.
+  }
 });
 ```
 
@@ -96,8 +110,8 @@ Example:
 ```js
 const send = createPinoBrowserSend({
   apiKey: "API_KEY",
-  sourceToken: "49e4f31e-f7e9-4f42-8c1e-xxxxxxxxxx"
-});
+  sourceToken: "49e4f31e-f7e9-4f42-8c1e-xxxxxxxxxx",
+})
 ```
 
 #### apiKey

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "batch2": "^1.0.6",
     "commander": "^5.0.0",
     "fast-json-parse": "^1.0.3",
-    "logflare-transport-core": "^0.3.0",
+    "logflare-transport-core": "^0.3.1",
     "pino": "^6.3.2",
     "pumpify": "^2.0.1",
     "split2": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "batch2": "^1.0.6",
     "commander": "^5.0.0",
     "fast-json-parse": "^1.0.3",
-    "logflare-transport-core": "^0.3.1",
+    "logflare-transport-core": "^0.3.3",
     "pino": "^6.3.2",
     "pumpify": "^2.0.1",
     "split2": "^3.1.1",

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -63,6 +63,25 @@ describe("main", () => {
     done()
   })
 
+  it("createWriteStream correctly calls onError callbacks", async (done) => {
+    const mockFn = jest.fn()
+    const stream = createWriteStream({
+      apiKey: "testApiKey",
+      sourceToken: "testSourceToken",
+      onError: mockFn,
+    })
+
+    global.fetch = jest.fn().mockImplementation(async () => {
+      throw new Error("some error")
+    })
+    const logger = pino({}, stream)
+    await logger.info({ some: "value" }, "should error")
+
+    expect(global.fetch).toBeCalledTimes(1)
+    expect(mockFn).toBeCalledTimes(1)
+    done()
+  })
+
   it("correctly logs metadata for child loggers", async (done) => {
     const { stream, send } = logflarePinoVercel({
       apiKey: "testApiKey",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1640,16 +1640,6 @@ batch2@^1.0.6:
   dependencies:
     through2 "^3.0.1"
 
-big-integer@^1.6.48:
-  version "1.6.48"
-  resolved "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
-  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
-
-bignumber.js@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
-  integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1981,7 +1971,7 @@ decamelize@^1.2.0:
   resolved "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
-decimal.js@^10.2.0, decimal.js@^10.2.1:
+decimal.js@^10.2.1:
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.0.tgz#97a7448873b01e92e5ff9117d89a7bca8e63e0fe"
   integrity sha512-Nv6ENEzyPQ6AItkGwLE2PGKinZZ9g59vSh2BeH6NqPu0OTKZ5ruJsVqh/orbAnqXc9pBbgXAIrc2EyaCj8NpGg==
@@ -3691,14 +3681,10 @@ lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.7.0:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-logflare-transport-core@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/logflare-transport-core/-/logflare-transport-core-0.3.1.tgz#93b74e99384b39cad7d5bfbf96fc485b1812b66a"
-  integrity sha512-wyjqtwiiXYekBXTRSLP1/JBq5nJwoq8ehvCxTrwW5M8f92TMTNf7xVaBrDeQlRxxcWd1llW8Fdapq5o2xMblPg==
-  dependencies:
-    big-integer "^1.6.48"
-    bignumber.js "^9.0.0"
-    decimal.js "^10.2.0"
+logflare-transport-core@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/logflare-transport-core/-/logflare-transport-core-0.3.3.tgz#dade63f6b414b7d01727825ce0ccb830ed6f0f7e"
+  integrity sha512-n82NsRVWvlaa3jd9QQ8rDroCjCJcIamQOlarLDBou9RsF0QaRv39rduy0ToPmlGQn1OPZBwlsv+R36lXupSmVQ==
 
 lru-cache@^6.0.0:
   version "6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3691,10 +3691,10 @@ lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.7.0:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-logflare-transport-core@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/logflare-transport-core/-/logflare-transport-core-0.3.0.tgz#a6510531d92c9ddb15f79a882ff2746f2fab1de6"
-  integrity sha512-k6zcKGVaCP8PdocYe0AAQC9AKJK5h8+1ujBisBfCRTk+KVYXAQUZ4gKMzhbOtQfN1zywzV8kBcen4wUyeWnhuw==
+logflare-transport-core@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/logflare-transport-core/-/logflare-transport-core-0.3.1.tgz#93b74e99384b39cad7d5bfbf96fc485b1812b66a"
+  integrity sha512-wyjqtwiiXYekBXTRSLP1/JBq5nJwoq8ehvCxTrwW5M8f92TMTNf7xVaBrDeQlRxxcWd1llW8Fdapq5o2xMblPg==
   dependencies:
     big-integer "^1.6.48"
     bignumber.js "^9.0.0"


### PR DESCRIPTION
This PR bumps the version of the `logflare-transport-core` to support the `onError` callback. This then allows users to handle ingestion failures on the rare occasion that the Logflare service has issues, or if there are errors client side that need to be handled (such as client connection issues).