### PR TITLE
chore: fix readme about retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A transport for [Pino](https://getpino.io/#/) that sends messages to Logflare.
 - Automatic batching of logs
 - Custom payload transformation
 - Vercel Edge Runtime support
-- Error handling and retries
+- Error handling
 - TypeScript support
 
 > [!NOTE]  


### PR DESCRIPTION
removes wrong features info as retries are not handled and should be handled by client.